### PR TITLE
bug:refractor login form validation error

### DIFF
--- a/src/app/login/login-form/login-form.component.html
+++ b/src/app/login/login-form/login-form.component.html
@@ -19,7 +19,7 @@
       Login to your account
     </div>
     <div>
-    <form fxLayout="column" [formGroup]="loginForm" id="login-form">
+    <form fxLayout="column" [formGroup]="loginForm" (keydown.enter)="login()" id="login-form">
 
       <mat-form-field fxFlexAlign="center" class="login-input">
     <span matPrefix>

--- a/src/app/login/login-form/login-form.component.html
+++ b/src/app/login/login-form/login-form.component.html
@@ -19,7 +19,7 @@
       Login to your account
     </div>
     <div>
-    <form fxLayout="column" [formGroup]="loginForm" (ngSubmit)="login()" id="login-form">
+    <form fxLayout="column" [formGroup]="loginForm" id="login-form">
 
       <mat-form-field fxFlexAlign="center" class="login-input">
     <span matPrefix>
@@ -35,10 +35,10 @@
         <input matInput type="{{ passwordInputType }}" placeholder="Password" formControlName="password">
       </mat-form-field>
 
-      <button mat-raised-button fxFlexAlign="center" *ngIf="loginForm.valid" class="login-button enabled" [disabled]="!loginForm.valid">
+      <button type="button" (click)="login()" mat-raised-button fxFlexAlign="center" *ngIf="loginForm.valid" class="login-button enabled" [disabled]="!loginForm.valid">
         Login
       </button>
-      <button mat-raised-button fxFlexAlign="center" *ngIf="!loginForm.valid" class="login-button disabled" [disabled]="!loginForm.valid">
+      <button type="button" (click)="login()" mat-raised-button fxFlexAlign="center" *ngIf="!loginForm.valid" class="login-button disabled" [disabled]="!loginForm.valid">
         Login
       </button>
 

--- a/src/app/login/login-form/login-form.component.html
+++ b/src/app/login/login-form/login-form.component.html
@@ -19,7 +19,7 @@
       Login to your account
     </div>
     <div>
-    <form fxLayout="column" [formGroup]="loginForm" (keydown.enter)="login()" id="login-form">
+    <form fxLayout="column" #formDirective="ngForm" [formGroup]="loginForm" (ngSubmit)="login(formDirective)" id="login-form">
 
       <mat-form-field fxFlexAlign="center" class="login-input">
     <span matPrefix>
@@ -35,10 +35,10 @@
         <input matInput type="{{ passwordInputType }}" placeholder="Password" formControlName="password">
       </mat-form-field>
 
-      <button type="button" (click)="login()" mat-raised-button fxFlexAlign="center" *ngIf="loginForm.valid" class="login-button enabled" [disabled]="!loginForm.valid">
+      <button mat-raised-button fxFlexAlign="center" *ngIf="loginForm.valid" class="login-button enabled" [disabled]="!loginForm.valid">
         Login
       </button>
-      <button type="button" (click)="login()" mat-raised-button fxFlexAlign="center" *ngIf="!loginForm.valid" class="login-button disabled" [disabled]="!loginForm.valid">
+      <button mat-raised-button fxFlexAlign="center" *ngIf="!loginForm.valid" class="login-button disabled" [disabled]="!loginForm.valid">
         Login
       </button>
 

--- a/src/app/login/login-form/login-form.component.ts
+++ b/src/app/login/login-form/login-form.component.ts
@@ -6,7 +6,7 @@ import { finalize } from 'rxjs/operators';
 
 /** Custom Services */
 import { AuthenticationService } from '../../core/authentication/authentication.service';
-import {AlertService} from '../../core/alert/alert.service';
+import { AlertService } from '../../core/alert/alert.service';
 
 @Component({
   selector: 'online-banking-login-form',
@@ -25,8 +25,8 @@ export class LoginFormComponent implements OnInit {
    * @param {AuthenticationService} authenticationService Authentication Service
    */
   constructor(private formBuilder: FormBuilder,
-              private authenticationService: AuthenticationService,
-              private alertService: AlertService) { }
+    private authenticationService: AuthenticationService,
+    private alertService: AlertService) { }
 
   /**
    * Create Login Form
@@ -40,7 +40,7 @@ export class LoginFormComponent implements OnInit {
   /**
    * Authenticate user credentials
    */
-  login(){
+  login() {
     this.loading = true;
     this.loginForm.disable();
     console.log('Trying to login with', this.loginForm.value);
@@ -49,6 +49,7 @@ export class LoginFormComponent implements OnInit {
       .pipe(finalize(() => {
         this.loginForm.reset();
         this.loginForm.markAsPristine();
+        this.loginForm.markAsUntouched();
         // Angular Material Bug: Validation errors won't get removed on reset.
         this.loginForm.enable();
         this.loading = false;
@@ -66,7 +67,7 @@ export class LoginFormComponent implements OnInit {
   /**
    * Create Login Form
    */
-  private createLoginForm(){
+  private createLoginForm() {
     this.loginForm = this.formBuilder.group({
       username: ['', Validators.required],
       password: ['', Validators.required]

--- a/src/app/login/login-form/login-form.component.ts
+++ b/src/app/login/login-form/login-form.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, FormGroupDirective } from '@angular/forms';
 
 /** rxjs Imports */
 import { finalize } from 'rxjs/operators';
@@ -40,16 +40,16 @@ export class LoginFormComponent implements OnInit {
   /**
    * Authenticate user credentials
    */
-  login() {
+  login(formDirective: FormGroupDirective) {
     this.loading = true;
     this.loginForm.disable();
     console.log('Trying to login with', this.loginForm.value);
     this.loginForm.enable();
     this.authenticationService.login(this.loginForm.value)
       .pipe(finalize(() => {
-        this.loginForm.reset();
+        formDirective.resetForm();
         this.loginForm.markAsPristine();
-        this.loginForm.markAsUntouched();
+        // this.loginForm.reset();
         // Angular Material Bug: Validation errors won't get removed on reset.
         this.loginForm.enable();
         this.loading = false;


### PR DESCRIPTION
Whenever we try to login in the app with correct username and password
the login form shows validation error.
It was due to by default, Angular/Material watch formControl's error state not only by ```touched``` but also ```submitted``` status of the form as the code you can see
```
isErrorState(control: FormControl | null, form: FormGroupDirective | NgForm | null): boolean {
  return !!(control && control.invalid && (control.touched || (form && form.submitted)));
                                                                       ^^^^^^^^^^^^^^
}
```
For reason above, you also need to reset the form to ```unsubmitted``` status.


Fixes #26

Fixed behaviour
![Correct_login](https://user-images.githubusercontent.com/59651136/104226581-0d3a6a80-546e-11eb-9568-519587fa0ce1.gif)
